### PR TITLE
fix: spacing between icon and text

### DIFF
--- a/src/pages/settingsPage/ProfilePage.jsx
+++ b/src/pages/settingsPage/ProfilePage.jsx
@@ -50,9 +50,9 @@ const ProfilePage = () => {
           </div>
 
           <Link to="/update_details">
-            <div>
-              <button className="edit_btn">
-                <BiEdit />
+            <div className="">
+              <button className="edit_btn ">
+                <BiEdit className="mr-1" />
                 Edit
               </button>
             </div>


### PR DESCRIPTION
Added spacing between the icon and the text to make it look better
![image](https://user-images.githubusercontent.com/70205370/215216474-a0141b54-864d-4345-a7be-9deb1adcaa3f.png)
